### PR TITLE
Frontend Filepicker Ordner Link

### DIFF
--- a/system/modules/pct_customelements_plugin_cc_frontedit/PCT/Contao/BackendMain.php
+++ b/system/modules/pct_customelements_plugin_cc_frontedit/PCT/Contao/BackendMain.php
@@ -77,6 +77,8 @@ class BackendMain extends \Contao\BackendMain
 		$strBuffer = str_replace(PCT_CUSTOMELEMENTS_PLUGIN_CC_FRONTEDIT_PATH.'/assets/html/', '', $strBuffer);
 		// form action must point to full path
 		$strBuffer = str_replace('main.php?',PCT_CUSTOMELEMENTS_PLUGIN_CC_FRONTEDIT_PATH.'/assets/html/main.php?',$strBuffer);
+		// folder link must be changed
+		$strBuffer = str_replace('app.php?',PCT_CUSTOMELEMENTS_PLUGIN_CC_FRONTEDIT_PATH.'/assets/html/main.php?',$strBuffer);
 		// set header
 		header('Content-Type: text/html; charset=' . \Config::get('characterSet'));
 		// print it and exit script


### PR DESCRIPTION
Im Frontend-Filepicker gibt es ein Problem bein Klick auf einen Ordner-Namen - dieser verlinkt auf app.php - auch diese Link muss korrekt ersetzt werden. Getestet in Contao 4.4.50 und Contao 4.9.4