### PR TITLE
Doppelter Ordner

### DIFF
--- a/system/modules/pct_customelements_plugin_cc_frontedit/Contao/Controllers/FrontendFile.php
+++ b/system/modules/pct_customelements_plugin_cc_frontedit/Contao/Controllers/FrontendFile.php
@@ -66,7 +66,7 @@ class FrontendFile extends \Contao\BackendFile
 			$root = array_merge($root,$objFiles->fetchEach('path'));
 		}
 		
-		$GLOBALS['TL_DCA']['tl_files']['list']['sorting']['root'] = $root;
+		$GLOBALS['TL_DCA']['tl_files']['list']['sorting']['root'] = array_unique($root);
 	}
 	
 	public function run()

--- a/system/modules/pct_customelements_plugin_cc_frontedit/PCT/Contao/Picker/FilePickerProvider.php
+++ b/system/modules/pct_customelements_plugin_cc_frontedit/PCT/Contao/Picker/FilePickerProvider.php
@@ -99,7 +99,7 @@ class FilePickerProvider extends \Contao\CoreBundle\Picker\FilePickerProvider
 				$root = array_merge($root,$objFiles->fetchEach('path'));
 			}
 			
-			$GLOBALS['TL_DCA']['tl_files']['list']['sorting']['root'] = $root;
+			$GLOBALS['TL_DCA']['tl_files']['list']['sorting']['root'] = array_unique($root);
 		}
 		
 		return $this->User;	   


### PR DESCRIPTION
Wenn beim Mitglied das Home-Verzeichnis eingestellt wurde sowie das gleiche Verzeichnis unter File-Mounts wird das Verzeichnis im Filepicker doppelt ausgegeben.